### PR TITLE
feat: 重构前端设计

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -1,7 +1,14 @@
 import { withDuxTheme } from '@duxweb/vitepress-theme/config'
+import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
 
 export default withDuxTheme({
   base: '/Pre-docs/',
+
+  markdown: {
+    config(md) {
+      md.use(tabsMarkdownPlugin)
+    }
+  },
   title: '先研实验室前置学习讲义',
   description: '太原理工大学"一生一芯"工作室前置讲义',
   lang: 'zh-CN',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitepress'
+import { withDuxTheme } from '@duxweb/vitepress-theme/config'
 
-export default defineConfig({
+export default withDuxTheme({
   base: '/Pre-docs/',
   title: '先研实验室前置学习讲义',
   description: '太原理工大学"一生一芯"工作室前置讲义',

--- a/.vitepress/theme/components/BackToTop.vue
+++ b/.vitepress/theme/components/BackToTop.vue
@@ -1,0 +1,127 @@
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+const progress = ref(0)
+const visible = ref(false)
+const R = 20
+const C = 2 * Math.PI * R
+
+let scrollTick = 0
+const onScroll = () => {
+  if (scrollTick) return
+  scrollTick = requestAnimationFrame(() => {
+    const el = document.documentElement
+    const max = el.scrollHeight - el.clientHeight
+    progress.value = max > 0 ? el.scrollTop / max : 0
+    visible.value = el.scrollTop > 100
+    scrollTick = 0
+  })
+}
+
+const toTop = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+const dash = computed(() => `${C * progress.value} ${C}`)
+
+onMounted(() => window.addEventListener('scroll', onScroll, { passive: true }))
+onUnmounted(() => window.removeEventListener('scroll', onScroll))
+</script>
+
+<template>
+  <Transition name="bt-fade">
+    <button
+      v-show="visible"
+      class="back-to-top"
+      aria-label="回到顶部"
+      @click="toTop"
+    >
+      <svg viewBox="0 0 48 48">
+        <circle class="bt-track" cx="24" cy="24" :r="R" />
+        <circle
+          class="bt-bar"
+          cx="24"
+          cy="24"
+          :r="R"
+          :stroke-dasharray="dash"
+        />
+      </svg>
+      <span class="bt-arrow">↑</span>
+    </button>
+  </Transition>
+</template>
+
+<style scoped>
+.back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 32px;
+  z-index: 50;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  background: var(--fluent-surface, rgba(255, 255, 255, 0.7));
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid var(--fluent-border, rgba(255, 255, 255, 0.5));
+  box-shadow: var(--fluent-shadow, 0 8px 24px rgba(0, 0, 0, 0.12));
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.back-to-top:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--fluent-shadow-hover, 0 14px 44px rgba(0, 0, 0, 0.2));
+}
+.back-to-top svg {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+.back-to-top circle {
+  fill: none;
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+.bt-track {
+  stroke: var(--color-primary-100, #dcf3fe);
+}
+.dark .bt-track {
+  stroke: var(--color-primary-800, #116b97);
+}
+.bt-bar {
+  stroke: var(--color-primary-500, #29b8ff);
+  transition: stroke-dasharray 0.15s linear;
+}
+.bt-arrow {
+  color: var(--color-primary-600, #06a1ef);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+}
+.dark .bt-arrow {
+  color: var(--color-primary-400, #66ccff);
+}
+
+/* Transition */
+.bt-fade-enter-active,
+.bt-fade-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.bt-fade-enter-from,
+.bt-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.8) translateY(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top {
+    transition: none;
+  }
+  .bt-fade-enter-active,
+  .bt-fade-leave-active {
+    transition: opacity 0.15s ease;
+  }
+}
+</style>

--- a/.vitepress/theme/components/Card.vue
+++ b/.vitepress/theme/components/Card.vue
@@ -1,0 +1,73 @@
+<script setup>
+defineProps({
+  title: { type: String, required: true },
+  icon: { type: String, default: '' },
+})
+</script>
+
+<template>
+  <div class="md-card">
+    <div v-if="icon" class="md-card-icon" v-html="icon" />
+    <div class="md-card-title">{{ title }}</div>
+    <div class="md-card-body">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.md-card {
+  background: var(--fluent-surface, rgba(255,255,255,.62));
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid var(--fluent-border, rgba(255,255,255,.55));
+  border-radius: var(--fluent-radius, 14px);
+  padding: 1.5rem;
+  transition: box-shadow 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+.md-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border-top: 1px solid var(--fluent-edge, rgba(255,255,255,.85));
+  pointer-events: none;
+}
+.md-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--fluent-shadow-hover, 0 14px 44px rgba(0,0,0,.2));
+  border-color: var(--color-primary-300);
+}
+.md-card-icon {
+  font-size: 1.8rem;
+  margin-bottom: 0.75rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: var(--color-primary-100);
+  color: var(--color-primary-600);
+}
+.dark .md-card-icon {
+  background: var(--color-primary-900);
+  color: var(--color-primary-400);
+}
+.md-card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--color-primary-700);
+}
+.dark .md-card-title {
+  color: var(--color-primary-300);
+}
+.md-card-body {
+  color: inherit;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+</style>

--- a/.vitepress/theme/components/CardGroup.vue
+++ b/.vitepress/theme/components/CardGroup.vue
@@ -1,0 +1,25 @@
+<script setup>
+defineProps({
+  cols: { type: Number, default: 2 },
+})
+</script>
+
+<template>
+  <div class="md-card-group" :style="{ '--cg-cols': cols }">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.md-card-group {
+  display: grid;
+  grid-template-columns: repeat(var(--cg-cols, 2), 1fr);
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+@media (max-width: 768px) {
+  .md-card-group {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/.vitepress/theme/components/FocusToggle.vue
+++ b/.vitepress/theme/components/FocusToggle.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+
+const STORAGE_KEY = 'dux-focus-mode'
+const enabled = ref(false)
+
+function toggle() { enabled.value = !enabled.value }
+function apply(val) {
+  document.documentElement.classList.toggle('focus-mode', val)
+  localStorage.setItem(STORAGE_KEY, val ? '1' : '0')
+}
+watch(enabled, apply)
+
+onMounted(() => {
+  if (localStorage.getItem(STORAGE_KEY) === '1') { enabled.value = true; apply(true) }
+})
+</script>
+
+<template>
+  <button
+    class="ft-btn"
+    :class="{ active: enabled }"
+    :aria-label="enabled ? '退出专注模式' : '专注模式'"
+    @click="toggle"
+  >
+    <span class="ft-icon" />
+    <span class="ft-label">{{ enabled ? '已专注' : '专注' }}</span>
+  </button>
+</template>
+
+<style scoped>
+.ft-btn {
+  position: fixed;
+  left: 16px;
+  bottom: 80px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 36px;
+  padding: 0 10px 0 8px;
+  border-radius: 20px;
+  cursor: pointer;
+  background: var(--fluent-surface, rgba(255,255,255,.7));
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid var(--fluent-border, rgba(255,255,255,.5));
+  box-shadow: var(--fluent-shadow, 0 8px 24px rgba(0,0,0,.12));
+  transition: transform .25s ease, border-color .25s ease, box-shadow .25s ease;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.ft-btn:hover { transform: scale(1.05); }
+.ft-btn.active {
+  border-color: var(--color-primary-400);
+  box-shadow: 0 0 16px rgba(102,204,255,.35);
+}
+
+.ft-icon {
+  width: 18px; height: 18px; display: block; flex-shrink: 0;
+  background: currentColor;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z'/%3E%3Ccircle cx='12' cy='12' r='3'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z'/%3E%3Ccircle cx='12' cy='12' r='3'/%3E%3C/svg%3E");
+  mask-size: contain; -webkit-mask-size: contain;
+  mask-repeat: no-repeat; -webkit-mask-repeat: no-repeat;
+  mask-position: center; -webkit-mask-position: center;
+  color: var(--color-gray-500);
+}
+.ft-btn.active .ft-icon { color: var(--color-primary-400); }
+
+.ft-label {
+  font-size: 12px; font-weight: 600;
+  color: var(--color-gray-500);
+  max-width: 0; overflow: hidden;
+  transition: max-width .25s ease;
+}
+.ft-btn:hover .ft-label,
+.ft-btn.active .ft-label { max-width: 60px; }
+.ft-btn.active .ft-label { color: var(--color-primary-600); }
+.dark .ft-label { color: var(--color-gray-400); }
+.dark .ft-btn.active .ft-label { color: var(--color-primary-400); }
+</style>

--- a/.vitepress/theme/components/ScrollReveal.vue
+++ b/.vitepress/theme/components/ScrollReveal.vue
@@ -1,0 +1,65 @@
+<script setup>
+import { onMounted, onUnmounted } from 'vue'
+
+const REVEAL_INIT = 'reveal-init'
+const REVEALED = 'revealed'
+
+let observer = null
+let domObserver = null
+
+function observe() {
+  requestAnimationFrame(() => {
+    const targets = document.querySelectorAll(
+      '.prose-content h2, .prose-content table, .prose-content .custom-block'
+    )
+    targets.forEach((el) => {
+      if (!el.classList.contains(REVEALED)) {
+        el.classList.add(REVEAL_INIT)
+      }
+    })
+    if (observer) {
+      targets.forEach((el) => observer.observe(el))
+    }
+  })
+}
+
+onMounted(() => {
+  if (typeof IntersectionObserver === 'undefined') return
+
+  observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add(REVEALED)
+          entry.target.classList.remove(REVEAL_INIT)
+          observer.unobserve(entry.target)
+        }
+      })
+    },
+    { threshold: 0.1 }
+  )
+
+  observe()
+
+  // SPA 导航后 .prose-content 会重建，用 MutationObserver 捕捉
+  domObserver = new MutationObserver(() => {
+    // 有新的 .prose-content 内容加入时重新扫描
+    if (document.querySelector('.prose-content')) {
+      observe()
+    }
+  })
+  domObserver.observe(document.body, {
+    childList: true,
+    subtree: true
+  })
+})
+
+onUnmounted(() => {
+  if (observer) { observer.disconnect(); observer = null }
+  if (domObserver) { domObserver.disconnect(); domObserver = null }
+})
+</script>
+
+<template>
+  <div style="display:none" aria-hidden="true" data-scroll-reveal />
+</template>

--- a/.vitepress/theme/components/ThemeColorPicker.vue
+++ b/.vitepress/theme/components/ThemeColorPicker.vue
@@ -1,0 +1,111 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const THEMES = {
+  blue:    { label: '天蓝',   color: '#66CCFF', colors: { '--color-primary-50':'#F0FAFE','--color-primary-100':'#DCF3FE','--color-primary-200':'#B8E7FF','--color-primary-300':'#8FDAFF','--color-primary-400':'#66CCFF','--color-primary-500':'#29B8FF','--color-primary-600':'#06A1EF','--color-primary-700':'#0A85C2','--color-primary-800':'#116B97','--color-primary-900':'#135272','--color-primary-950':'#0C3245' }},
+  emerald: { label: '翡翠',   color: '#34D399', colors: { '--color-primary-50':'#ECFDF5','--color-primary-100':'#D1FAE5','--color-primary-200':'#A7F3D0','--color-primary-300':'#6EE7B7','--color-primary-400':'#34D399','--color-primary-500':'#10B981','--color-primary-600':'#059669','--color-primary-700':'#047857','--color-primary-800':'#065F46','--color-primary-900':'#064E3B','--color-primary-950':'#022C22' }},
+  violet:  { label: '紫罗兰', color: '#A78BFA', colors: { '--color-primary-50':'#F5F3FF','--color-primary-100':'#EDE9FE','--color-primary-200':'#DDD6FE','--color-primary-300':'#C4B5FD','--color-primary-400':'#A78BFA','--color-primary-500':'#8B5CF6','--color-primary-600':'#7C3AED','--color-primary-700':'#6D28D9','--color-primary-800':'#5B21B6','--color-primary-900':'#4C1D95','--color-primary-950':'#2E1065' }},
+  rose:    { label: '玫瑰',   color: '#FB7185', colors: { '--color-primary-50':'#FFF1F2','--color-primary-100':'#FFE4E6','--color-primary-200':'#FECDD3','--color-primary-300':'#FDA4AF','--color-primary-400':'#FB7185','--color-primary-500':'#F43F5E','--color-primary-600':'#E11D48','--color-primary-700':'#BE123C','--color-primary-800':'#9F1239','--color-primary-900':'#881337','--color-primary-950':'#4C0519' }},
+  amber:   { label: '琥珀',   color: '#FBBF24', colors: { '--color-primary-50':'#FFFBEB','--color-primary-100':'#FEF3C7','--color-primary-200':'#FDE68A','--color-primary-300':'#FCD34D','--color-primary-400':'#FBBF24','--color-primary-500':'#F59E0B','--color-primary-600':'#D97706','--color-primary-700':'#B45309','--color-primary-800':'#92400E','--color-primary-900':'#78350F','--color-primary-950':'#451A03' }},
+  cyan:    { label: '青碧',   color: '#22D3EE', colors: { '--color-primary-50':'#ECFEFF','--color-primary-100':'#CFFAFE','--color-primary-200':'#A5F3FC','--color-primary-300':'#67E8F9','--color-primary-400':'#22D3EE','--color-primary-500':'#06B6D4','--color-primary-600':'#0891B2','--color-primary-700':'#0E7490','--color-primary-800':'#155E75','--color-primary-900':'#164E63','--color-primary-950':'#083344' }},
+}
+
+const STORAGE_KEY = 'dux-primary-color'
+const active = ref('blue')
+const open = ref(false)
+
+function applyTheme(key) {
+  const t = THEMES[key]
+  if (!t) return
+  const root = document.documentElement
+  Object.entries(t.colors).forEach(([prop, val]) => root.style.setProperty(prop, val))
+}
+
+function switchTo(key) {
+  active.value = key
+  applyTheme(key)
+  localStorage.setItem(STORAGE_KEY, key)
+  open.value = false
+}
+
+onMounted(() => {
+  const saved = localStorage.getItem(STORAGE_KEY)
+  if (saved && THEMES[saved]) { active.value = saved; applyTheme(saved) }
+})
+</script>
+
+<template>
+  <div class="cp-root" :class="{ open }">
+    <button class="cp-btn" aria-label="切换主题色" @click="open = !open">
+      <span class="cp-dot" :style="{ background: THEMES[active].color }" />
+      <span class="cp-btn-label">主题色</span>
+    </button>
+    <Transition name="cp-pop">
+      <div v-show="open" class="cp-panel">
+        <button
+          v-for="(t, key) in THEMES" :key="key"
+          class="cp-opt" :class="{ active: active === key }"
+          :title="t.label" @click="switchTo(key)"
+        >
+          <span class="cp-swatch" :style="{ background: t.color }" />
+          <span class="cp-lbl">{{ t.label }}</span>
+        </button>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.cp-root { position: fixed; left: 16px; bottom: 32px; z-index: 50; }
+.cp-btn {
+  display: flex; align-items: center; gap: 8px;
+  height: 36px; padding: 0 10px 0 8px;
+  border-radius: 20px; cursor: pointer;
+  background: var(--fluent-surface, rgba(255,255,255,.7));
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid var(--fluent-border, rgba(255,255,255,.5));
+  box-shadow: var(--fluent-shadow, 0 8px 24px rgba(0,0,0,.12));
+  transition: transform .25s ease, box-shadow .25s ease;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.cp-btn:hover { transform: scale(1.05); box-shadow: var(--fluent-shadow-hover); }
+.cp-dot { width: 18px; height: 18px; border-radius: 50%; flex-shrink: 0; }
+.cp-btn-label { font-size: 12px; font-weight: 600; color: var(--color-gray-600); max-width: 0; overflow: hidden; transition: max-width .25s ease, margin .25s ease; }
+.cp-btn:hover .cp-btn-label, .cp-root.open .cp-btn-label { max-width: 60px; }
+.dark .cp-btn-label { color: var(--color-gray-300); }
+
+/* 面板：向右弹出 */
+.cp-panel {
+  position: absolute; left: 48px; bottom: 0;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px;
+  padding: 8px;
+  background: var(--fluent-surface, rgba(255,255,255,.7));
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid var(--fluent-border, rgba(255,255,255,.5));
+  border-radius: 14px;
+  box-shadow: var(--fluent-shadow, 0 8px 24px rgba(0,0,0,.12));
+}
+.cp-opt {
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 5px 8px; border-radius: 8px; cursor: pointer;
+  background: transparent; border: none; color: inherit;
+  font-size: 10px; white-space: nowrap; min-width: 48px;
+  transition: background .2s ease;
+}
+.cp-opt:hover { background: rgba(128,128,128,.1); }
+.cp-opt.active { background: var(--color-primary-100); }
+.dark .cp-opt.active { background: var(--color-primary-900); }
+.cp-swatch {
+  width: 20px; height: 20px; border-radius: 50%; flex-shrink: 0;
+  border: 2px solid transparent; transition: border-color .2s ease;
+}
+.cp-opt.active .cp-swatch { border-color: var(--fluent-border); box-shadow: 0 0 0 2px var(--fluent-surface); }
+.cp-lbl { color: var(--color-gray-600); line-height: 1.2; }
+.dark .cp-lbl { color: var(--color-gray-300); }
+
+.cp-pop-enter-active, .cp-pop-leave-active { transition: opacity .2s ease, transform .2s cubic-bezier(.22,1,.36,1); }
+.cp-pop-enter-from, .cp-pop-leave-to { opacity: 0; transform: translateX(-8px) scale(.95); }
+</style>

--- a/.vitepress/theme/components/Timeline.vue
+++ b/.vitepress/theme/components/Timeline.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="md-timeline">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.md-timeline {
+  position: relative;
+  padding-left: 2rem;
+  margin: 1.5rem 0;
+}
+.md-timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    var(--color-primary-400),
+    var(--color-primary-200)
+  );
+  border-radius: 1px;
+}
+.dark .md-timeline::before {
+  background: linear-gradient(
+    to bottom,
+    var(--color-primary-500),
+    var(--color-primary-800)
+  );
+}
+</style>

--- a/.vitepress/theme/components/TimelineItem.vue
+++ b/.vitepress/theme/components/TimelineItem.vue
@@ -1,0 +1,63 @@
+<script setup>
+defineProps({
+  time: { type: String, default: '' },
+  title: { type: String, default: '' },
+})
+</script>
+
+<template>
+  <div class="md-timeline-item">
+    <div class="md-ti-dot" />
+    <div v-if="time" class="md-ti-time">{{ time }}</div>
+    <div v-if="title" class="md-ti-title">{{ title }}</div>
+    <div class="md-ti-body">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.md-timeline-item {
+  position: relative;
+  padding-bottom: 1.5rem;
+  padding-left: 1.5rem;
+}
+.md-timeline-item:last-child {
+  padding-bottom: 0;
+}
+.md-ti-dot {
+  position: absolute;
+  left: -1.55rem;
+  top: 0.35rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-primary-400);
+  border: 2px solid var(--fluent-surface, #fff);
+  box-shadow: 0 0 0 3px var(--color-primary-200);
+  z-index: 1;
+}
+.dark .md-ti-dot {
+  border-color: var(--fluent-surface, #1c1e22);
+  box-shadow: 0 0 0 3px var(--color-primary-800);
+}
+.md-ti-time {
+  font-size: 0.8rem;
+  color: var(--color-primary-500);
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.dark .md-ti-time {
+  color: var(--color-primary-400);
+}
+.md-ti-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+.md-ti-body {
+  color: inherit;
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+</style>

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -151,22 +151,248 @@ aside {
 }
 
 /* ============================================================
-   7. 提示块 / Callout：轻玻璃
+   7. Custom-block：Fluent 玻璃拟态 · 湿润反射 · 弹性悬浮（增强版）
    ============================================================ */
 .prose-content .custom-block {
-  border-radius: var(--fluent-radius);
-  border: 1px solid var(--fluent-border);
-  /* 不覆盖 background，保留主题各类型专属底色 (info=蓝 tip=绿 warning=黄 danger=红) */
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--fluent-radius, 14px);
+  border: 1px solid var(--fluent-border, rgba(255,255,255,.5));
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+
+  /* 双层静态反射：顶部镜面封层 + 对角光泽 */
+  background-image:
+    linear-gradient(180deg, rgba(255,255,255,.42) 0%, rgba(255,255,255,0) 30%),
+    linear-gradient(135deg, rgba(255,255,255,.28) 0%, rgba(255,255,255,0) 45%);
+
+  /* 顶部镜面高光线 + 底部微反光 + 柔和投影 */
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.85),
+    inset 0 -1px 0 rgba(255,255,255,.12),
+    var(--fluent-shadow, 0 8px 32px rgba(19,82,114,.12));
+
+  /* 弹性曲线：过冲回弹 */
+  transition:
+    transform .38s cubic-bezier(.34, 1.56, .64, 1),
+    box-shadow .3s ease,
+    border-color .3s ease;
 }
 
-/* 修复：引用块内 strong / bold — 同色系半透明底色高亮（仅上下 padding） */
-.prose-content .custom-block strong {
-  color: inherit;
-  background: color-mix(in oklab, currentColor 18%, transparent);
-  padding: 0.08em 0;
-  border-radius: 3px;
+/* 动态扫光层（hover 时斜向掠过） */
+.prose-content .custom-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(105deg,
+    transparent 35%,
+    rgba(255,255,255,.14) 45%,
+    rgba(255,255,255,.55) 50%,
+    rgba(255,255,255,.14) 55%,
+    transparent 65%);
+  transform: translateX(-130%) skewX(-8deg);
+  transition: transform .9s var(--ease-fluid, cubic-bezier(.22, 1, .36, 1));
+  pointer-events: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .prose-content .custom-block:hover {
+    transform: translateY(-4px) scale(1.01);
+    border-color: rgba(255,255,255,.75);
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,.95),
+      inset 0 -1px 0 rgba(255,255,255,.16),
+      var(--fluent-shadow-hover, 0 14px 44px rgba(19,82,114,.20));
+  }
+  .prose-content .custom-block:hover::after {
+    transform: translateX(130%) skewX(-8deg);
+  }
+  .prose-content .custom-block:active {
+    transform: translateY(-1px) scale(.997);
+    transition-duration: .12s;
+  }
+}
+
+/* ---- 语义类型配色 ---- */
+/* tip */
+.prose-content .custom-block.tip {
+  background-color: rgba(16,185,129,.10);
+  color: #065F46;
+  border-color: rgba(16,185,129,.22);
+  border-left: 3px solid #10B981;
+}
+
+/* warning */
+.prose-content .custom-block.warning {
+  background-color: rgba(245,158,11,.10);
+  color: #92400E;
+  border-color: rgba(245,158,11,.25);
+  border-left: 3px solid #F59E0B;
+}
+
+/* danger / caution */
+.prose-content .custom-block.danger,
+.prose-content .custom-block.caution {
+  background-color: rgba(239,68,68,.10);
+  color: #991B1B;
+  border-color: rgba(239,68,68,.25);
+  border-left: 3px solid #EF4444;
+}
+
+/* info / note */
+.prose-content .custom-block.info,
+.prose-content .custom-block.note {
+  background-color: rgba(41,184,255,.10);
+  color: var(--color-primary-800, #116B97);
+  border-color: rgba(41,184,255,.25);
+  border-left: 3px solid var(--color-primary-500, #29B8FF);
+}
+
+/* important */
+.prose-content .custom-block.important {
+  background-color: rgba(139,92,246,.10);
+  color: #5B21B6;
+  border-color: rgba(139,92,246,.25);
+  border-left: 3px solid #8B5CF6;
+}
+
+/* details */
+.prose-content .custom-block.details {
+  background-color: rgba(107,114,128,.08);
+  color: #374151;
+  border-color: rgba(107,114,128,.20);
+  border-left: 3px solid #9CA3AF;
+}
+
+.prose-content .custom-block .custom-block-title { font-weight: 700; }
+
+/* ============================================================
+   8. 粗体修复：语义色马克笔横扫
+   ============================================================ */
+
+/* 剥掉灰色涂层 */
+.prose-content .custom-block strong,
+.prose-content .custom-block b {
+  background-color: transparent !important;
+  background-image: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  font-weight: 700;
+}
+
+/* 马克笔扫层（底部 40% 语义浅色） */
+.prose-content .custom-block.tip strong,
+.prose-content .custom-block.tip b {
+  color: #064E3B;
+  background-image: linear-gradient(transparent 60%, rgba(16,185,129,.32) 60%) !important;
+}
+.prose-content .custom-block.warning strong,
+.prose-content .custom-block.warning b {
+  color: #78350F;
+  background-image: linear-gradient(transparent 60%, rgba(245,158,11,.34) 60%) !important;
+}
+.prose-content .custom-block.danger strong,
+.prose-content .custom-block.danger b,
+.prose-content .custom-block.caution strong,
+.prose-content .custom-block.caution b {
+  color: #7F1D1D;
+  background-image: linear-gradient(transparent 60%, rgba(239,68,68,.30) 60%) !important;
+}
+.prose-content .custom-block.info strong,
+.prose-content .custom-block.info b,
+.prose-content .custom-block.note strong,
+.prose-content .custom-block.note b {
+  color: var(--color-primary-900, #135272);
+  background-image: linear-gradient(transparent 60%, rgba(41,184,255,.32) 60%) !important;
+}
+.prose-content .custom-block.important strong,
+.prose-content .custom-block.important b {
+  color: #4C1D95;
+  background-image: linear-gradient(transparent 60%, rgba(139,92,246,.30) 60%) !important;
+}
+
+/* ============================================================
+   暗色模式（反射强度降低）
+   ============================================================ */
+.dark .prose-content .custom-block {
+  background-image:
+    linear-gradient(180deg, rgba(255,255,255,.10) 0%, rgba(255,255,255,0) 30%),
+    linear-gradient(135deg, rgba(255,255,255,.07) 0%, rgba(255,255,255,0) 45%);
+  box-shadow:
+    inset 0 1px 0 rgba(255,255,255,.14),
+    inset 0 -1px 0 rgba(255,255,255,.04),
+    var(--fluent-shadow, 0 8px 32px rgba(0,0,0,.45));
+}
+.dark .prose-content .custom-block::after {
+  background: linear-gradient(105deg,
+    transparent 35%,
+    rgba(255,255,255,.05) 45%,
+    rgba(255,255,255,.16) 50%,
+    rgba(255,255,255,.05) 55%,
+    transparent 65%);
+}
+@media (hover: hover) and (pointer: fine) {
+  .dark .prose-content .custom-block:hover {
+    border-color: rgba(255,255,255,.18);
+    box-shadow:
+      inset 0 1px 0 rgba(255,255,255,.20),
+      inset 0 -1px 0 rgba(255,255,255,.06),
+      var(--fluent-shadow-hover, 0 14px 44px rgba(0,0,0,.60));
+  }
+}
+
+.dark .prose-content .custom-block.tip {
+  background-color: rgba(16,185,129,.12); color: #A7F3D0;
+}
+.dark .prose-content .custom-block.warning {
+  background-color: rgba(245,158,11,.12); color: #FDE68A;
+}
+.dark .prose-content .custom-block.danger,
+.dark .prose-content .custom-block.caution {
+  background-color: rgba(239,68,68,.12); color: #FECACA;
+}
+.dark .prose-content .custom-block.info,
+.dark .prose-content .custom-block.note {
+  background-color: rgba(41,184,255,.12); color: var(--color-primary-100, #DCF3FE);
+}
+.dark .prose-content .custom-block.important {
+  background-color: rgba(139,92,246,.12); color: #DDD6FE;
+}
+.dark .prose-content .custom-block.details {
+  background-color: rgba(107,114,128,.12); color: #D1D5DB;
+}
+
+/* 暗色模式马克笔扫层（亮档色 + 低不透明度） */
+.dark .prose-content .custom-block.tip strong,
+.dark .prose-content .custom-block.tip b {
+  color: #D1FAE5;
+  background-image: linear-gradient(transparent 60%, rgba(52,211,153,.24) 60%) !important;
+}
+.dark .prose-content .custom-block.warning strong,
+.dark .prose-content .custom-block.warning b {
+  color: #FEF3C7;
+  background-image: linear-gradient(transparent 60%, rgba(251,191,36,.22) 60%) !important;
+}
+.dark .prose-content .custom-block.danger strong,
+.dark .prose-content .custom-block.danger b,
+.dark .prose-content .custom-block.caution strong,
+.dark .prose-content .custom-block.caution b {
+  color: #FEE2E2;
+  background-image: linear-gradient(transparent 60%, rgba(248,113,113,.22) 60%) !important;
+}
+.dark .prose-content .custom-block.info strong,
+.dark .prose-content .custom-block.info b,
+.dark .prose-content .custom-block.note strong,
+.dark .prose-content .custom-block.note b {
+  color: #FFFFFF;
+  background-image: linear-gradient(transparent 60%, rgba(102,204,255,.26) 60%) !important;
+}
+.dark .prose-content .custom-block.important strong,
+.dark .prose-content .custom-block.important b {
+  color: #EDE9FE;
+  background-image: linear-gradient(transparent 60%, rgba(167,139,250,.22) 60%) !important;
 }
 
 /* ============================================================

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,0 +1,551 @@
+/* ============================================================
+   .vitepress/theme/custom.css
+   必须在 @duxweb/vitepress-theme/dist/index.css 之后引入
+   ============================================================ */
+
+/* ============================================================
+   1. 主色令牌：#66CCFF 全色阶（锚定 400）
+   覆写 Tailwind v4 --color-primary-* 色阶
+   ============================================================ */
+:root {
+  --color-primary-50:  #F0FAFE;
+  --color-primary-100: #DCF3FE;
+  --color-primary-200: #B8E7FF;
+  --color-primary-300: #8FDAFF;
+  --color-primary-400: #66CCFF;   /* 视觉主色 */
+  --color-primary-500: #29B8FF;
+  --color-primary-600: #06A1EF;
+  --color-primary-700: #0A85C2;
+  --color-primary-800: #116B97;
+  --color-primary-900: #135272;
+  --color-primary-950: #0C3245;
+
+  /* VitePress 原生品牌色对齐 */
+  --vp-c-brand:       var(--color-primary-500);
+  --vp-c-brand-light: var(--color-primary-400);
+  --vp-c-brand-dark:  var(--color-primary-600);
+
+  /* ============================================================
+     2. Fluent 亚克力材质令牌（亮色模式）
+     ============================================================ */
+  --fluent-blur:         20px;
+  --fluent-saturate:     180%;
+  --fluent-surface:      rgba(255, 255, 255, 0.62);
+  --fluent-surface-soft: rgba(255, 255, 255, 0.45);
+  --fluent-border:       rgba(255, 255, 255, 0.55);
+  --fluent-edge:         rgba(255, 255, 255, 0.85);
+  --fluent-shadow:       0 8px 32px rgba(19, 82, 114, 0.12);
+  --fluent-shadow-hover: 0 14px 44px rgba(19, 82, 114, 0.20);
+  --fluent-radius:       14px;
+}
+
+/* 暗色模式：反转令牌 */
+.dark {
+  --vp-c-brand:       var(--color-primary-400);
+  --vp-c-brand-light: var(--color-primary-300);
+  --vp-c-brand-dark:  var(--color-primary-500);
+
+  --fluent-surface:      rgba(28, 30, 34, 0.58);
+  --fluent-surface-soft: rgba(28, 30, 34, 0.40);
+  --fluent-border:       rgba(255, 255, 255, 0.09);
+  --fluent-edge:         rgba(255, 255, 255, 0.14);
+  --fluent-shadow:       0 8px 32px rgba(0, 0, 0, 0.45);
+  --fluent-shadow-hover: 0 14px 44px rgba(0, 0, 0, 0.6);
+}
+
+/* ============================================================
+   3. 导航栏 Header：亚克力毛玻璃
+   选择器: header（主题源码 Layout 中唯一的 <header> 元素）
+   主题已内置 backdrop-blur + bg-white/95，这里强化为 Fluent 材质
+   ============================================================ */
+header {
+  background: var(--fluent-surface) !important;
+  backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
+  -webkit-backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
+  border-bottom-color: var(--fluent-border) !important;
+  box-shadow: var(--fluent-shadow);
+}
+
+/* ============================================================
+   4. 侧边栏 Sidebar：半透明材质
+   选择器: aside（Sidebar.vue.js 中的 <aside> 元素）
+   桌面端 md:bg-transparent → 改为玻璃；移动端已有 bg-white 底色
+   ============================================================ */
+aside {
+  background: var(--fluent-surface-soft) !important;
+  backdrop-filter: blur(calc(var(--fluent-blur) * 0.6)) saturate(150%);
+  -webkit-backdrop-filter: blur(calc(var(--fluent-blur) * 0.6)) saturate(150%);
+}
+/* 桌面端侧边栏右边线 */
+@media (min-width: 768px) {
+  aside {
+    border-right: 1px solid var(--fluent-border);
+  }
+}
+
+/* ============================================================
+   5. 首页特性卡片：玻璃表面 + Reveal 悬浮高光
+   选择器: .home .grid 容器下的直接卡片子元素
+   Features.vue.js 中卡片使用 rounded-3xl bg-white dark:bg-gray-800
+   ============================================================ */
+.home .grid > a,
+.home .grid > div {
+  background: var(--fluent-surface) !important;
+  backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
+  -webkit-backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
+  border-color: var(--fluent-border) !important;
+  border-radius: var(--fluent-radius) !important;
+  box-shadow: var(--fluent-shadow);
+  transition: transform 0.3s var(--ease-fluid, ease),
+              box-shadow 0.3s var(--ease-fluid, ease),
+              border-color 0.3s ease;
+}
+/* Fluent 顶部高光线 */
+.home .grid > a::before,
+.home .grid > div::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border-top: 1px solid var(--fluent-edge);
+  pointer-events: none;
+  z-index: 1;
+}
+/* 悬浮效果 */
+.home .grid > a:hover,
+.home .grid > div:hover {
+  box-shadow: var(--fluent-shadow-hover) !important;
+  border-color: var(--color-primary-300) !important;
+}
+
+/* ============================================================
+   6. 正文链接与行内代码：保证对比度
+   选择器: .prose-content（Doc.vue.js 中内容容器）
+   亮色用 600 保证对比度，暗色用 400
+   ============================================================ */
+.prose-content a {
+  color: var(--color-primary-600);
+  text-decoration-color: var(--color-primary-200);
+  transition: color 0.2s ease;
+}
+.prose-content a:hover {
+  color: var(--color-primary-500);
+}
+.dark .prose-content a {
+  color: var(--color-primary-400);
+}
+.dark .prose-content a:hover {
+  color: var(--color-primary-300);
+}
+
+.prose-content :not(pre) > code {
+  color: var(--color-primary-700);
+  background: var(--color-primary-50);
+  border-radius: 6px;
+  padding: 0.15em 0.4em;
+  font-size: 0.9em;
+}
+.dark .prose-content :not(pre) > code {
+  color: var(--color-primary-300);
+  background: rgba(102, 204, 255, 0.12);
+}
+
+/* ============================================================
+   7. 提示块 / Callout：轻玻璃
+   ============================================================ */
+.prose-content .custom-block {
+  border-radius: var(--fluent-radius);
+  border: 1px solid var(--fluent-border);
+  /* 不覆盖 background，保留主题各类型专属底色 (info=蓝 tip=绿 warning=黄 danger=红) */
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+/* 修复：引用块内 strong / bold — 同色系半透明底色高亮（仅上下 padding） */
+.prose-content .custom-block strong {
+  color: inherit;
+  background: color-mix(in oklab, currentColor 18%, transparent);
+  padding: 0.08em 0;
+  border-radius: 3px;
+}
+
+/* ============================================================
+   8. 首页 Hero：分层光晕背景
+   选择器: .home section（Hero.vue.js 渲染的第一个 <section>）
+   ============================================================ */
+.home section {
+  position: relative;
+  overflow: hidden;
+}
+.home section::before,
+.home section::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+}
+.home section::before {
+  width: 520px;
+  height: 520px;
+  top: -160px;
+  right: -120px;
+  background: radial-gradient(circle, var(--color-primary-300), transparent 70%);
+}
+.home section::after {
+  width: 420px;
+  height: 420px;
+  bottom: -180px;
+  left: -100px;
+  background: radial-gradient(circle, var(--color-primary-200), transparent 70%);
+}
+.dark .home section::before { opacity: 0.35; }
+.dark .home section::after  { opacity: 0.30; }
+
+/* Hero 主按钮：Fluent 强调色
+   选择器: .btn-primary（duxweb 主题按钮组件类） */
+.btn-primary {
+  background: var(--color-primary-400) !important;
+  color: #06283d !important;
+  border: 1px solid var(--fluent-edge) !important;
+  border-radius: 10px !important;
+  box-shadow: 0 4px 16px rgba(102, 204, 255, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+.btn-primary:hover {
+  background: var(--color-primary-300) !important;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(102, 204, 255, 0.55);
+}
+
+/* ============================================================
+   9. DocFooter 上一篇/下一篇：轻玻璃按钮
+   ============================================================ */
+.doc-footer .nav-link a {
+  background: var(--fluent-surface-soft);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-color: var(--fluent-border) !important;
+  border-radius: var(--fluent-radius);
+}
+
+/* ============================================================
+   10. 搜索按钮：主题色
+   ============================================================ */
+.SearchButton {
+  /* 搜索按钮使用主题色强调 */
+}
+
+/* ============================================================
+   11. 滚动条细节
+   ============================================================ */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--color-primary-200);
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+.dark ::-webkit-scrollbar-thumb {
+  background: var(--color-primary-800);
+  background-clip: content-box;
+}
+
+/* ============================================================
+   12. 滚动渐显 (ScrollReveal)
+   对 h2 / 表格 / custom-block 做淡入上移动画，仅触发一次
+   ============================================================ */
+.reveal-init {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease,
+              transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.revealed {
+  opacity: 1;
+  transform: none;
+}
+
+/* ============================================================
+   13. 导航链接对比度增强
+   毛玻璃背景下 gray-600 偏淡，提升至 gray-800 / gray-200
+   ============================================================ */
+.nav-dropdown-button,
+.nav-dropdown-link {
+  color: var(--color-gray-800) !important;
+  font-weight: 600;
+}
+.dark .nav-dropdown-button,
+.dark .nav-dropdown-link {
+  color: var(--color-gray-200) !important;
+}
+/* hover / active 保持主题色 */
+.nav-dropdown-button:hover,
+.nav-dropdown-link:hover {
+  color: var(--color-gray-900) !important;
+}
+.dark .nav-dropdown-button:hover,
+.dark .nav-dropdown-link:hover {
+  color: var(--color-gray-100) !important;
+}
+.nav-dropdown-link.active,
+.nav-dropdown-button.active {
+  color: var(--color-primary-600) !important;
+  font-weight: 700;
+}
+.dark .nav-dropdown-link.active,
+.dark .nav-dropdown-button.active {
+  color: var(--color-primary-400) !important;
+}
+
+/* 导航章节分隔线 */
+.nav-dropdown-depth-0 {
+  position: relative;
+}
+.nav-dropdown-depth-0:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  right: -0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 1.25rem;
+  width: 1px;
+  background: var(--color-gray-300);
+  border-radius: 1px;
+}
+.dark .nav-dropdown-depth-0:not(:last-child)::after {
+  background: var(--color-gray-600);
+}
+
+/* ── 侧边栏现代化 ── */
+
+/* 侧边栏滚动条加宽 */
+aside .overflow-y-auto {
+  max-height: calc(100vh - 12rem) !important;
+}
+aside .overflow-y-auto::-webkit-scrollbar {
+  width: 8px;
+}
+aside .overflow-y-auto::-webkit-scrollbar-thumb {
+  background: var(--color-gray-300);
+  border-radius: 4px;
+}
+aside .overflow-y-auto::-webkit-scrollbar-thumb:hover {
+  background: var(--color-gray-400);
+}
+.dark aside .overflow-y-auto::-webkit-scrollbar-thumb {
+  background: var(--color-gray-600);
+}
+.dark aside .overflow-y-auto::-webkit-scrollbar-thumb:hover {
+  background: var(--color-gray-500);
+}
+
+/* 分组标题：左 accent 线 + 更大间距 */
+.sidebar-group-title {
+  position: relative;
+  padding-left: 0.85rem !important;
+  margin-top: 0.75rem;
+  margin-bottom: 0.6rem !important;
+  font-size: 0.8rem !important;
+  font-weight: 700 !important;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-gray-500) !important;
+}
+.dark .sidebar-group-title {
+  color: var(--color-gray-400) !important;
+}
+.sidebar-group-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 70%;
+  background: var(--color-primary-400);
+  border-radius: 2px;
+}
+
+/* 分组之间分隔线 */
+.sidebar-group + .sidebar-group {
+  border-top: 1px solid var(--color-gray-200);
+  padding-top: 0.5rem;
+}
+.dark .sidebar-group + .sidebar-group {
+  border-top-color: var(--color-gray-700);
+}
+
+/* ── 二级分组折叠：默认收起，点击标题展开 ── */
+.sidebar-group-items .ml-2 h4 {
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  padding-right: 18px !important;
+}
+/* 折叠箭头 */
+.sidebar-group-items .ml-2 h4::after {
+  content: '';
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%) rotate(-90deg);
+  width: 0; height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid var(--color-gray-400);
+  transition: transform 0.25s ease;
+}
+.sidebar-group-items .sg-nested-open h4::after {
+  transform: translateY(-50%) rotate(0deg);
+}
+/* 默认隐藏子列表 */
+.sidebar-group-items .ml-2 ul {
+  display: none;
+}
+.sidebar-group-items .sg-nested-open ul {
+  display: block;
+}
+
+/* 统一嵌套标题与链接项间距，取消父级缩进 */
+.sidebar-group-items .ml-2 h4 {
+  padding: 0.45rem 0.75rem !important;
+  margin-bottom: 0 !important;
+  margin-left: -0.5rem !important;
+  font-size: 0.88rem !important;
+}
+
+/* 链接项：更大点击区域 + 平滑过渡 */
+.sidebar-group-items a,
+.sidebar-nav > div > a {
+  padding: 0.45rem 0.75rem !important;
+  margin: 1px 0;
+  border-radius: 8px !important;
+  font-size: 0.88rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+/* 激活态：更醒目的左侧色条 */
+.sidebar-group-items a[class*='bg-primary'],
+.sidebar-nav > div > a[class*='bg-primary'] {
+  border-left-width: 3px !important;
+  border-radius: 0 8px 8px 0 !important;
+  font-weight: 600;
+}
+
+/* 未激活态 hover */
+.sidebar-group-items a:hover,
+.sidebar-nav > div > a:hover {
+  background: var(--color-gray-100) !important;
+}
+.dark .sidebar-group-items a:hover,
+.dark .sidebar-nav > div > a:hover {
+  background: rgba(255,255,255,0.06) !important;
+}
+
+/* ============================================================
+   14. 专注模式
+   开启后导航/侧边栏/目录变模糊半透明，hover 恢复
+   ============================================================ */
+.focus-mode header,
+.focus-mode aside,
+.focus-mode .sticky.top-16 {
+  opacity: 0.06;
+  filter: blur(8px);
+  transition: opacity 0.5s ease, filter 0.5s ease;
+}
+.focus-mode header:hover,
+.focus-mode aside:hover,
+.focus-mode .sticky.top-16:hover {
+  opacity: 1;
+  filter: none;
+}
+/* 专注模式下主内容区轻微居中突出 */
+.focus-mode main {
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ============================================================
+   15. 暗色切换：圆形展开过渡 (View Transition API)
+   主题已有 startViewTransition，这里叠加 clip-path 动画
+   ============================================================ */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 9999;
+  animation: vt-circle-open 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes vt-circle-open {
+  from {
+    clip-path: circle(0% at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+  to {
+    clip-path: circle(150% at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+}
+
+/* ============================================================
+   16. 首页入场动画
+   主题已有 scale-in/fade-in，这里替换为淡入上移 + stagger
+   ============================================================ */
+@keyframes home-rise {
+  from {
+    opacity: 0;
+    transform: translateY(28px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Hero 标题区 */
+.home section .fade-in {
+  animation: home-rise 0.7s var(--ease-fluid, cubic-bezier(0.22, 1, 0.36, 1)) both;
+}
+.home section .fade-in:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+/* Hero 按钮 */
+.home section .scale-in {
+  animation: home-rise 0.6s var(--ease-fluid, cubic-bezier(0.22, 1, 0.36, 1)) both;
+  animation-delay: 0.35s;
+}
+
+/* 特性卡片 stagger：复用组件内已有的 animation-delay inline style */
+.home .grid > a,
+.home .grid > div {
+  animation: home-rise 0.6s var(--ease-fluid, cubic-bezier(0.22, 1, 0.36, 1)) both;
+}
+
+/* ============================================================
+   18. 隐藏阅读时间（保留字数）
+   ============================================================ */
+.prose .not-prose > :first-child {
+  display: none;
+}
+
+/* ============================================================
+   19. 无障碍：尊重系统减少动效偏好
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,7 +1,88 @@
+import { createApp, h } from 'vue'
 import Theme from '@duxweb/vitepress-theme'
 import '@duxweb/vitepress-theme/dist/index.css'
+import './custom.css'
 import './style.css'
+
+import BackToTop from './components/BackToTop.vue'
+import ScrollReveal from './components/ScrollReveal.vue'
+import ThemeColorPicker from './components/ThemeColorPicker.vue'
+import FocusToggle from './components/FocusToggle.vue'
+
+import Card from './components/Card.vue'
+import CardGroup from './components/CardGroup.vue'
+import Timeline from './components/Timeline.vue'
+import TimelineItem from './components/TimelineItem.vue'
+
+import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
+
+function mount(id, component) {
+  const el = document.createElement('div')
+  el.id = id
+  document.body.appendChild(el)
+  createApp({ render: () => h(component) }).mount(el)
+}
 
 export default {
   extends: Theme,
+
+  enhanceApp({ app }) {
+    app.component('Card', Card)
+    app.component('CardGroup', CardGroup)
+    app.component('Timeline', Timeline)
+    app.component('TimelineItem', TimelineItem)
+    enhanceAppWithTabs(app)
+  },
+
+  setup() {
+    if (typeof document === 'undefined') return
+
+    document.addEventListener('click', (e) => {
+      const toggle = e.target.closest('.theme-toggle')
+      if (!toggle) return
+      const root = document.documentElement
+      root.style.setProperty('--vt-x', e.clientX + 'px')
+      root.style.setProperty('--vt-y', e.clientY + 'px')
+    })
+
+    mount('bt-container', BackToTop)
+    mount('sr-container', ScrollReveal)
+    mount('cp-container', ThemeColorPicker)
+    mount('ft-container', FocusToggle)
+
+    // 二级分组默认折叠
+    initNestedCollapse()
+  }
+}
+
+/* ── 侧边栏二级分组折叠 ── */
+function initNestedCollapse() {
+  const KEY = 'sidebar-nested'
+  const openSet = new Set(JSON.parse(localStorage.getItem(KEY) || '[]'))
+
+  function apply() {
+    document.querySelectorAll('.sidebar-group-items .ml-2').forEach((el) => {
+      const h4 = el.querySelector('h4')
+      if (!h4) return
+      const id = h4.textContent.trim()
+      el.classList.toggle('sg-nested-open', openSet.has(id))
+    })
+  }
+
+  apply()
+
+  document.addEventListener('click', (e) => {
+    const h4 = e.target.closest('.sidebar-group-items .ml-2 h4')
+    if (!h4) return
+    const group = h4.closest('.ml-2')
+    const id = h4.textContent.trim()
+    if (openSet.has(id)) { openSet.delete(id) }
+    else { openSet.add(id) }
+    group.classList.toggle('sg-nested-open', openSet.has(id))
+    localStorage.setItem(KEY, JSON.stringify([...openSet]))
+  })
+
+  new MutationObserver(() => {
+    if (document.querySelector('.sidebar-group-items .ml-2')) apply()
+  }).observe(document.body, { childList: true, subtree: true })
 }

--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,4 +1,7 @@
-import DefaultTheme from 'vitepress/theme'
+import Theme from '@duxweb/vitepress-theme'
+import '@duxweb/vitepress-theme/dist/index.css'
 import './style.css'
 
-export default DefaultTheme
+export default {
+  extends: Theme,
+}

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -1,29 +1,30 @@
-/* Global style overrides can go here */
+/* ── 标题排版 ── */
 
 /* h1: 桌面端不换行，移动端用 pretty 防孤字 */
-.vp-doc h1 {
+.prose-content h1 {
   white-space: nowrap;
 }
 
 @media (max-width: 768px) {
-  .vp-doc h1 {
+  .prose-content h1 {
     white-space: normal;
     text-wrap: pretty;
   }
 }
 
 /* h2/h3 较短，用 balance：多行时均衡分布更美观 */
-.vp-doc h2,
-.vp-doc h3 {
+.prose-content h2,
+.prose-content h3 {
   text-wrap: balance;
 }
 
 /* ── 侧边栏标题同样防止孤字 ── */
-.VPSidebarItem .text {
+.docs-nav-link,
+.docs-nav-category {
   text-wrap: pretty;
 }
 
-/* 修复 callout 块内标题过大问题 */
+/* ── 修复 callout 块内标题过大问题 ── */
 .custom-block h1 {
   font-size: 1.30em;
   margin: 0 0 0.4em;
@@ -40,4 +41,3 @@
   border: none;
   padding-top: 0;
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "preparatory-materials",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@duxweb/vitepress-theme": "^1.1.9"
+      },
       "devDependencies": {
         "vitepress": "^1.6.3"
       }
@@ -13,7 +17,6 @@
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
       "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -29,7 +32,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
       "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
@@ -40,7 +42,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
       "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.17.7"
@@ -53,7 +54,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
       "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.17.7"
@@ -67,7 +67,6 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
       "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -78,7 +77,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
       "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -94,7 +92,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
       "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -110,7 +107,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
       "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
@@ -120,7 +116,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
       "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -136,7 +131,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
       "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -152,7 +146,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
       "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -168,7 +161,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
       "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -184,7 +176,6 @@
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
       "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -200,7 +191,6 @@
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
       "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -216,7 +206,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
       "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1",
@@ -232,7 +221,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
       "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1"
@@ -245,7 +233,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
       "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1"
@@ -258,7 +245,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
       "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/client-common": "5.55.1"
@@ -267,11 +253,23 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -281,7 +279,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -291,7 +288,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -307,7 +303,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -317,18 +312,39 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@cyberalien/svg-utils": {
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@cyberalien/svg-utils/-/svg-utils-1.2.19.tgz",
+      "integrity": "sha512-paDJoDu+LhuH5Ma1q0BDqBpg6d16Xk22cZZrlg/s/J9oB8KgnnpU/snaEETJu2G1pwYcWQINUz6WUqu0Wm9k6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      }
+    },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
       "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@docsearch/js": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
       "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "3.8.2",
@@ -339,7 +355,6 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
       "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.17.7",
@@ -368,6 +383,117 @@
         }
       }
     },
+    "node_modules/@duxweb/vitepress-theme": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@duxweb/vitepress-theme/-/vitepress-theme-1.1.9.tgz",
+      "integrity": "sha512-FuwBvU/tQuaLOhARfVdty1oan0QVYzWOp83r8dOyG+ViO1Qf5xbNzzsw8S+48V0yG9s68WueN6wkP50cSxvZhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/tailwind4": "^1.0.6",
+        "@vueuse/core": "^11.3.0",
+        "dayjs": "^1.11.20",
+        "minisearch": "^7.1.2",
+        "vitepress-mermaid-renderer": "^1.1.8",
+        "vue": "^3.5.18"
+      },
+      "peerDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@vueuse/core": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-11.3.0.tgz",
+      "integrity": "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "11.3.0",
+        "@vueuse/shared": "11.3.0",
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@vueuse/metadata": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-11.3.0.tgz",
+      "integrity": "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@vueuse/shared": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-11.3.0.tgz",
+      "integrity": "sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@duxweb/vitepress-theme/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -375,7 +501,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,7 +517,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,7 +533,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,7 +549,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -443,7 +565,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -460,7 +581,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -477,7 +597,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -494,7 +613,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -511,7 +629,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -528,7 +645,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -545,7 +661,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,7 +677,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -579,7 +693,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -596,7 +709,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -613,7 +725,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -630,7 +741,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -647,7 +757,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -664,7 +773,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -681,7 +789,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -698,7 +805,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -715,7 +821,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -732,7 +837,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -749,7 +853,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,25 +866,75 @@
       "version": "1.2.88",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.88.tgz",
       "integrity": "sha512-+cvi1qCuvReL29ehi6t62L4fb7GDXe+UlGHFcsJcV7I2l9wtqn9XE2IBKcDr3CI5iGUGS5ISnXv699pSGpyx1Q==",
-      "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/tailwind4": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify/tailwind4/-/tailwind4-1.2.3.tgz",
+      "integrity": "sha512-z8SKiMHRASJKF/IY//87MF88lcB7ulxh8vlhQXXLWsBkNtOh6ese9R41MyGpQeqXdRvQVt+/fX2glQtHFjQ+MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/tools": "^5.0.5",
+        "@iconify/types": "^2.0.0",
+        "@iconify/utils": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">= 4.0.0"
+      }
+    },
+    "node_modules/@iconify/tools": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@iconify/tools/-/tools-5.0.12.tgz",
+      "integrity": "sha512-aFPwSFmFphUPVjNLUkgxgUPSPVgTEEjv0mE7NgvfoQBuE5TtsMrKa4HTY65cM5oXZ2a1xKQcW/RKhiOKEiAarw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cyberalien/svg-utils": "^1.2.15",
+        "@iconify/types": "^2.0.0",
+        "@iconify/utils": "^3.1.3",
+        "fflate": "^0.8.3",
+        "modern-tar": "^0.7.6",
+        "pathe": "^2.0.3",
+        "svgo": "^4.0.1"
       }
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -790,7 +943,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -804,7 +956,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -818,7 +969,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -832,7 +982,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -846,7 +995,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,7 +1008,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,7 +1021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,7 +1034,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -902,7 +1047,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -916,7 +1060,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -930,7 +1073,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,7 +1086,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,7 +1099,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -972,7 +1112,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,7 +1125,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,7 +1138,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1014,7 +1151,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1028,7 +1164,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1042,7 +1177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,7 +1190,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,7 +1203,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1084,7 +1216,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,7 +1229,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1112,7 +1242,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1255,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1265,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
       "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/engine-javascript": "2.5.0",
@@ -1152,7 +1279,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
       "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.5.0",
@@ -1164,7 +1290,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
       "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.5.0",
@@ -1175,7 +1300,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
       "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.5.0"
@@ -1185,7 +1309,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
       "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "2.5.0"
@@ -1195,7 +1318,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
       "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "2.5.0",
@@ -1206,7 +1328,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
       "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -1217,21 +1338,309 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1241,14 +1650,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -1259,7 +1666,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1269,35 +1675,49 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
       "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
       "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -1311,7 +1731,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
       "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -1325,7 +1744,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
       "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.39",
@@ -1336,7 +1754,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
       "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -1354,7 +1771,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
       "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.39",
@@ -1365,7 +1781,6 @@
       "version": "7.7.10",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
       "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-kit": "^7.7.10"
@@ -1375,7 +1790,6 @@
       "version": "7.7.10",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
       "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/devtools-shared": "^7.7.10",
@@ -1391,7 +1805,6 @@
       "version": "7.7.10",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
       "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rfdc": "^1.4.1"
@@ -1401,7 +1814,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
       "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.39"
@@ -1411,7 +1823,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
       "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.39",
@@ -1422,7 +1833,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
       "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.39",
@@ -1435,7 +1845,6 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
       "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.39",
@@ -1449,14 +1858,12 @@
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
       "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
       "version": "12.8.2",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
       "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
@@ -1472,7 +1879,6 @@
       "version": "12.8.2",
       "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
       "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "12.8.2",
@@ -1539,7 +1945,6 @@
       "version": "12.8.2",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
       "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1549,7 +1954,6 @@
       "version": "12.8.2",
       "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
       "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vue": "^3.5.13"
@@ -1562,7 +1966,6 @@
       "version": "5.55.1",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
       "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@algolia/abtesting": "1.21.1",
@@ -1588,17 +1991,21 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
       "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1609,7 +2016,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1620,7 +2026,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1631,18 +2036,26 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
       "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-what": "^5.2.0"
@@ -1654,18 +2067,657 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1675,7 +2727,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -1685,18 +2736,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/emoji-regex-xs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
     },
-    "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1705,11 +2762,90 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1748,14 +2884,18 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/focus-trap": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
       "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.4.0"
@@ -1765,7 +2905,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1776,11 +2915,17 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -1804,7 +2949,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -1818,25 +2962,55 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
       "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1845,11 +3019,57 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "peer": true
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -1859,14 +3079,25 @@
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -1884,11 +3115,46 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1909,7 +3175,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1926,7 +3191,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1948,7 +3212,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1965,7 +3228,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -1982,21 +3244,27 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
       "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2011,11 +3279,22 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
       "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",
@@ -2023,25 +3302,59 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2070,7 +3383,6 @@
       "version": "10.29.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
       "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2081,7 +3393,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
       "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2092,7 +3403,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
       "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -2102,7 +3412,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -2112,21 +3421,25 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -2167,11 +3480,46 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/search-insights": {
       "version": "2.17.3",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
       "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -2179,7 +3527,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
       "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "2.5.0",
@@ -2196,7 +3543,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2206,7 +3552,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2217,7 +3562,6 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2227,7 +3571,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -2238,11 +3581,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
       "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "copy-anything": "^4"
@@ -2251,29 +3600,86 @@
         "node": ">=16"
       }
     },
+    "node_modules/svgo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
       "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -2287,7 +3693,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -2301,7 +3706,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -2315,7 +3719,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -2331,7 +3734,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -2342,11 +3744,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -2361,7 +3776,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -2376,7 +3790,6 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -2436,7 +3849,6 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
       "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@docsearch/css": "3.8.2",
@@ -2474,11 +3886,23 @@
         }
       }
     },
+    "node_modules/vitepress-mermaid-renderer": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/vitepress-mermaid-renderer/-/vitepress-mermaid-renderer-1.1.28.tgz",
+      "integrity": "sha512-cEZAIaTr5TEEsdKJZSkUtOz8ZH3hPHIXU8jkEI3RnxsnphN84QR6TuTJEIxmX4wceMFkw26nDZ86Z9gFiG6hJw==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.0",
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
       "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.39",
@@ -2500,7 +3924,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "preparatory-materials",
       "hasInstallScript": true,
       "dependencies": {
-        "@duxweb/vitepress-theme": "^1.1.9"
+        "@duxweb/vitepress-theme": "^1.1.9",
+        "vitepress-plugin-tabs": "^0.9.1"
       },
       "devDependencies": {
         "vitepress": "^1.6.3"
@@ -3897,6 +3898,20 @@
       "peerDependencies": {
         "mermaid": "^11.0.0",
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vitepress-plugin-tabs": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-tabs/-/vitepress-plugin-tabs-0.9.1.tgz",
+      "integrity": "sha512-cRys9pWhyl5YnxXZ3BAdSDW8DriuXBewYhmUu4bBlnzksEDjzbKUwbNi30T74Vi1UXnY1a19Ap6DJDTOWJWdzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
+      },
+      "peerDependencies": {
+        "vitepress": "^1.0.0 || ^2.0.0-alpha.17",
+        "vue": "^3.5.0"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "vitepress": "^1.6.3"
   },
   "dependencies": {
-    "@duxweb/vitepress-theme": "^1.1.9"
+    "@duxweb/vitepress-theme": "^1.1.9",
+    "vitepress-plugin-tabs": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build && node scripts/copy-assets.js",
-    "preview": "vitepress preview"
+    "preview": "vitepress preview",
+    "postinstall": "node scripts/patch-dux-footer.js"
   },
   "devDependencies": {
     "vitepress": "^1.6.3"
+  },
+  "dependencies": {
+    "@duxweb/vitepress-theme": "^1.1.9"
   }
 }

--- a/scripts/patch-dux-footer.js
+++ b/scripts/patch-dux-footer.js
@@ -1,0 +1,35 @@
+// Postinstall: patch duxweb DocFooter to use withBase() for prev/next links
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const target = resolve(
+  import.meta.dirname,
+  '..',
+  'node_modules/@duxweb/vitepress-theme/dist/esm/components/docs/DocFooter.vue.js'
+)
+
+let content = readFileSync(target, 'utf-8')
+
+// Only apply if not already patched
+if (!content.includes('withBase as wb')) {
+  // 1. Add withBase import
+  content = content.replace(
+    'import { useData as D } from "vitepress";',
+    'import { useData as D, withBase as wb } from "vitepress";'
+  )
+  // 2. Patch prev link
+  content = content.replace(
+    'href: n.value.prev.link,',
+    'href: wb(n.value.prev.link),'
+  )
+  // 3. Patch next link
+  content = content.replace(
+    'href: n.value.next.link,',
+    'href: wb(n.value.next.link),'
+  )
+
+  writeFileSync(target, content)
+  console.log('[postinstall] Patched duxweb DocFooter withBase fix')
+} else {
+  console.log('[postinstall] duxweb DocFooter already patched, skipping')
+}


### PR DESCRIPTION
## 📝 修改说明

<!-- 简要描述这个 PR 做了什么 -->

重构前端设计，前端设计更加现代化
1. 加入主题色选择和沉浸模式
2. 优化TIP块等高亮块的粗体显示
3. 加入部分动画

## 🔍 修改类型

- [ ] 讲义新版本更新
- [ ] 错别字修正
- [ ] 格式调整
- [ ] 内容补充
- [ ] 链接修复
- [ ] 图片更新
- [x] 其他

## ✅ PR 前检查

- [x] 已确认没有提交无关文件（node_modules、.env 等）
- [x] 我已检查过修改后的内容正确、格式正确
- [x] 如果是 Markdown 内容，已在本地预览过排版效果
- [x] 分支已同步 main 分支的最新代码

## 📷 截图（如有 UI 变更）

<!-- 拖入截图 -->

- 前端 preview
<img width="2560" height="1286" alt="image" src="https://github.com/user-attachments/assets/4c8ad840-1e4e-47f5-95a1-7bd73b5b16c6" />
<img width="2560" height="1298" alt="image" src="https://github.com/user-attachments/assets/48f08b17-6ce5-4c84-990d-a524662ff18b" />


- 专注模式
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/52fb04f7-fd6c-4b90-bf4b-2a442d7f1beb" />

- 主题色选择
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/6d303042-e5bf-4a74-848e-a7ca91562941" />


## 🔗 关联 Issue

<!-- 如果有关联的 Issue，请在此引用：Fixes #123 -->
